### PR TITLE
Laga timeToBBQ + lite småfix

### DIFF
--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -424,9 +424,9 @@ def marvinTimeToBBQ(row, asList=None, asStr=None):
             msg = getString("barbecue", "today")
         elif daysRemaining == 1:
             msg = getString("barbecue", "tomorrow")
-        elif daysRemaining < 14 and daysRemaining > 0:
+        elif 0 < daysRemaining < 14:
             msg = getString("barbecue", "week") % nextDate
-        elif daysRemaining < 200 and daysRemaining > 0:
+        elif 0 < daysRemaining < 200:
             msg = getString("barbecue", "base") % nextDate
         else:
             msg = getString("barbecue", "eternity") % nextDate

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -434,13 +434,15 @@ def marvinTimeToBBQ(row, asList=None, asStr=None):
         return url + ". " + msg
 
 
-def nextBBQ(after=datetime.date.today()):
+def nextBBQ():
     """
-    Calculate the next grillcon date after a given date (or from today)
+    Calculate the next grillcon date after today
     """
+
     MAY = 5
     SEPTEMBER = 9
 
+    after = datetime.date.today()
     spring = thirdFridayIn(after.year, MAY)
     if after <= spring:
         return spring

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -424,9 +424,9 @@ def marvinTimeToBBQ(row, asList=None, asStr=None):
             msg = getString("barbecue", "today")
         elif daysRemaining == 1:
             msg = getString("barbecue", "tomorrow")
-        elif 0 < daysRemaining < 14:
+        elif 1 < daysRemaining < 14:
             msg = getString("barbecue", "week") % nextDate
-        elif 0 < daysRemaining < 200:
+        elif 14 < daysRemaining < 200:
             msg = getString("barbecue", "base") % nextDate
         else:
             msg = getString("barbecue", "eternity") % nextDate


### PR DESCRIPTION
tydligen körs funktioner i defaultvärden när funktionen importeras, inte när funktionen körs, så utan denna ändringen kommer samma datum att returneras varje gång.

när jag höll på att fixa det så såg jag en varning som jag lagade, och när jag lagade varningen så såg jag att intervallen var lite märkligt överlappande (varför ska vi kolla om < 0 varje gång?).

antar att botten inte är drift längre, men rätt ska vara rätt...