### PR TITLE
Change API towards actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ prepare:
 # target: test                - Run all tests.
 .PHONY: test
 #test: prepare jsonlint pylint pycodestyle flake8 unittest doctest coverage
-test: prepare jsonlint pylint # pycodestyle flake8 unittest doctest coverage
+test: prepare jsonlint pylint unittest # pycodestyle flake8 doctest coverage
 	@$(call HELPTEXT,$@)
 
 
@@ -126,7 +126,7 @@ flake8:
 .PHONY: unittest
 unittest:
 	@$(call HELPTEXT,$@)
-	python3 -m unittest discover -b -s tests
+	python3 -m unittest discover
 
 
 

--- a/marvin.py
+++ b/marvin.py
@@ -288,13 +288,13 @@ def checkMarvinActions(words):
 
         if CONFIG["nick"] in row:
             for action in ACTIONS:
-                msg = action(set(row), row, raw)
+                msg = action(row)
                 if msg:
                     sendPrivMsg(msg, words[2])
                     break
         else:
             for action in GENERAL_ACTIONS:
-                msg = action(set(row), row, raw)
+                msg = action(row)
                 if msg:
                     sendPrivMsg(msg, words[2])
                     break

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -281,7 +281,7 @@ def marvinLunch(row, asList=None, asStr=None):
         'ängelholm angelholm engelholm': 'lunch-angelholm',
         'hässleholm hassleholm': 'lunch-hassleholm',
         'malmö malmo malmoe': 'lunch-malmo',
-        'göteborg gbg': 'lunch-goteborg'
+        'göteborg goteborg gbg': 'lunch-goteborg'
     }
 
     if row.intersection(['lunch', 'mat', 'äta', 'luncha']):

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -83,101 +83,100 @@ def getString(key, key1=None):
     return res
 
 
-def marvinSmile(row, asList=None, asStr=None):
+def marvinSmile(row):
     """
     Make Marvin smile.
     """
     msg = None
-    if row.intersection(['smile', 'le', 'skratta', 'smilies']):
+    if any(r in row for r in ["smile", "le", "skratta", "smilies"]):
         smilie = getString("smile")
         msg = "{SMILE}".format(SMILE=smilie)
     return msg
 
 
-def marvinGoogle(row, asList=None, asStr=None):
+def wordsAfterKeyWords(words, keyWords):
+    """
+    Return all items in the words list after the first occurence
+    of an item in the keyWords list.
+    """
+    kwIndex = []
+    for kw in keyWords:
+        if kw in words:
+            kwIndex.append(words.index(kw))
+
+    if not kwIndex:
+        return None
+
+    return words[min(kwIndex)+1:]
+
+
+def marvinGoogle(row):
     """
     Let Marvin present an url to google.
     """
-    msg = None
-    match = row.intersection(['google', 'googla'])
+    query = wordsAfterKeyWords(row, ["google", "googla"])
+    if not query:
+        return None
 
-    if match:
-        # Find the google word and take the rest as the query string
-        startAt = next(iter(match))
-        searchStart = asList.index(startAt) + 1
-
-        if searchStart >= len(asList):
-            searchStr = ""
-        else:
-            searchStr = " ".join(asList[searchStart:])
-
-        url = "https://www.google.se/search?q="
-        url += quote_plus(searchStr)
-        google = getString("google")
-        msg = google.format(url)
-
-    return msg
+    searchStr = " ".join(query)
+    url = "https://www.google.se/search?q="
+    url += quote_plus(searchStr)
+    msg = getString("google")
+    return msg.format(url)
 
 
-def marvinExplainShell(row, asList=None, asStr=None):
+def marvinExplainShell(row):
     """
     Let Marvin present an url to the service explain shell to
     explain a shell command.
     """
-    msg = None
-    match = row.intersection(['explain', 'förklara'])
-
-    if match:
-        # Find the matching word and take the rest as the query string
-        matchedStr = match.pop()
-        startAt = asStr.find(matchedStr) + len(matchedStr)
-        searchStr = asStr[startAt:].strip()
-
-        url = "http://explainshell.com/explain?cmd="
-        url += quote_plus(searchStr, "/:")
-        explain = getString("explainShell")
-        msg = explain.format(url)
-
-    return msg
+    query = wordsAfterKeyWords(row, ["explain", "förklara"])
+    if not query:
+        return None
+    cmd = " ".join(query)
+    url = "http://explainshell.com/explain?cmd="
+    url += quote_plus(cmd, "/:")
+    msg = getString("explainShell")
+    return msg.format(url)
 
 
-def marvinSource(row, asList=None, asStr=None):
+def marvinSource(row):
     """
     State message about sourcecode.
     """
     msg = None
-    if row.intersection(['källkod', 'source']):
+    if any(r in row for r in ["källkod", "source"]):
         msg = getString("source")
 
     return msg
 
 
-def marvinBudord(row, asList=None, asStr=None):
+def marvinBudord(row):
     """
     What are the budord for Marvin?
     """
     msg = None
-    if row.intersection(['budord', 'stentavla']):
-        if row.intersection(['1', '#1']):
+    if any(r in row for r in ["budord", "stentavla"]):
+        if any(r in row for r in ["#1", "1"]):
             msg = getString("budord", "#1")
-        elif row.intersection(['2', '#2']):
+        elif any(r in row for r in ["#2", "2"]):
             msg = getString("budord", "#2")
-        elif row.intersection(['3', '#3']):
+        elif any(r in row for r in ["#3", "3"]):
             msg = getString("budord", "#3")
-        elif row.intersection(['4', '#4']):
+        elif any(r in row for r in ["#4", "4"]):
             msg = getString("budord", "#4")
-        elif row.intersection(['5', '#5']):
+        elif any(r in row for r in ["#5", "5"]):
             msg = getString("budord", "#5")
 
     return msg
 
 
-def marvinQuote(row, asList=None, asStr=None):
+def marvinQuote(row):
     """
     Make a quote.
     """
     msg = None
-    if row.intersection(['quote', 'citat', 'filosofi', 'filosofera']):
+    if any(r in row for r in ["quote", "citat", "filosofi", "filosofera"]):
         msg = getString("hitchhiker")
 
     return msg
@@ -199,70 +198,71 @@ def videoOfToday():
     return msg
 
 
-def marvinVideoOfToday(row, asList=None, asStr=None):
+def marvinVideoOfToday(row):
     """
     Show the video of today.
     """
     msg = None
-    if row.intersection(['idag', 'dagens']) and row.intersection(['video', 'youtube', 'tube']):
-        msg = videoOfToday()
+    if any(r in row for r in ["idag", "dagens"]):
+        if any(r in row for r in ["video", "youtube", "tube"]):
+            msg = videoOfToday()
 
     return msg
 
 
-def marvinWhoIs(row, asList=None, asStr=None):
+def marvinWhoIs(row):
     """
     Who is Marvin.
     """
     msg = None
-    if row.issuperset(['vem', 'är']):
+    if all(r in row for r in ["vem", "är"]):
         msg = getString("whois")
 
     return msg
 
 
-def marvinHelp(row, asList=None, asStr=None):
+def marvinHelp(row):
     """
     Provide a menu.
     """
     msg = None
-    if row.intersection(['hjälp', 'help', 'menu', 'meny']):
+    if any(r in row for r in ["hjälp", "help", "menu", "meny"]):
         msg = getString("menu")
 
     return msg
 
 
-def marvinStats(row, asList=None, asStr=None):
+def marvinStats(row):
     """
     Provide a link to the stats.
     """
     msg = None
-    if row.intersection(['stats', 'statistik', 'ircstats']):
+    if any(r in row for r in ["stats", "statistik", "ircstats"]):
         msg = getString("ircstats")
 
     return msg
 
 
-def marvinIrcLog(row, asList=None, asStr=None):
+def marvinIrcLog(row):
     """
     Provide a link to the irclog
     """
     msg = None
-    if row.intersection(['irc', 'irclog', 'log', 'irclogg', 'logg', 'historik']):
+    if any(r in row for r in ["irc", "irclog", "log", "irclogg", "logg", "historik"]):
         msg = getString("irclog")
 
     return msg
 
 
-def marvinSayHi(row, asList=None, asStr=None):
+def marvinSayHi(row):
     """
     Say hi with a nice message.
     """
     msg = None
-    if row.intersection([
-            'snälla', 'hej', 'tjena', 'morsning', 'morrn', 'mår', 'hallå',
-            'halloj', 'läget', 'snäll', 'duktig', 'träna', 'träning',
-            'utbildning', 'tack', 'tacka', 'tackar', 'tacksam'
+    if any(r in row for r in [
+            "snälla", "hej", "tjena", "morsning", "morrn", "mår", "hallå",
+            "halloj", "läget", "snäll", "duktig", "träna", "träning",
+            "utbildning", "tack", "tacka", "tackar", "tacksam"
     ]):
         smile = getString("smile")
         hello = getString("hello")
@@ -272,7 +272,7 @@ def marvinSayHi(row, asList=None, asStr=None):
     return msg
 
 
-def marvinLunch(row, asList=None, asStr=None):
+def marvinLunch(row):
     """
     Help decide where to eat.
     """
@@ -284,11 +284,11 @@ def marvinLunch(row, asList=None, asStr=None):
         'göteborg goteborg gbg': 'lunch-goteborg'
     }
 
-    if row.intersection(['lunch', 'mat', 'äta', 'luncha']):
+    if any(r in row for r in ["lunch", "mat", "äta", "luncha"]):
         lunchStr = getString('lunch-message')
 
         for keys, value in lunchOptions.items():
-            if row.intersection(keys.split(' ')):
+            if any(r in row for r in keys.split(" ")):
                 return lunchStr.format(getString(value))
 
         return lunchStr.format(getString('lunch-bth'))
@@ -296,13 +296,12 @@ def marvinLunch(row, asList=None, asStr=None):
     return None
 
 
-def marvinListen(row, asList=None, asStr=None):
+def marvinListen(row):
     """
     Return music last listened to.
     """
     msg = None
-
-    if row.intersection(['lyssna', 'lyssnar', 'musik']):
+    if any(r in row for r in ["lyssna", "lyssnar", "musik"]):
 
         if not CONFIG["lastfm"]:
             return getString("listen", "disabled")
@@ -333,12 +332,12 @@ def marvinListen(row, asList=None, asStr=None):
     return msg
 
 
-def marvinSun(row, asList=None, asStr=None):
+def marvinSun(row):
     """
     Check when the sun goes up and down.
     """
     msg = None
-    if row.intersection(['sol', 'solen', 'solnedgång', 'soluppgång']):
+    if any(r in row for r in ["sol", "solen", "solnedgång", "soluppgång"]):
         try:
             soup = BeautifulSoup(urlopen('http://www.timeanddate.com/sun/sweden/jonkoping'))
             spans = soup.find_all("span", {"class": "three"})
@@ -352,12 +351,12 @@ def marvinSun(row, asList=None, asStr=None):
     return msg
 
 
-def marvinWeather(row, asList=None, asStr=None):
+def marvinWeather(row):
     """
     Check what the weather prognosis looks like.
     """
     msg = None
-    if row.intersection(["väder", "vädret", "prognos", "prognosen", "smhi"]):
+    if any(r in row for r in ["väder", "vädret", "prognos", "prognosen", "smhi"]):
         url = getString("smhi", "url")
         try:
             soup = BeautifulSoup(urlopen(url))
@@ -373,13 +372,13 @@ def marvinWeather(row, asList=None, asStr=None):
     return msg
 
 
-def marvinStrip(row, asList=None, asStr=None):
+def marvinStrip(row):
     """
     Get a comic strip.
     """
     msg = None
-    if row.intersection(['strip', 'comic', 'nöje', 'paus']):
-        if row.intersection(['rand', 'random', 'slump', 'lucky']):
+    if any(r in row for r in ["strip", "comic", "nöje", "paus"]):
+        if any(r in row for r in ["rand", "random", "slump", "lucky"]):
             msg = commitStrip(randomize=True)
         else:
             msg = commitStrip()
@@ -409,12 +408,12 @@ def commitStrip(randomize=False):
 #        feed=feedparser.parse(FEED_FORUM)
 
 
-def marvinTimeToBBQ(row, asList=None, asStr=None):
+def marvinTimeToBBQ(row):
     """
     Calcuate the time to next barbecue and print a appropriate msg
     """
     msg = None
-    if row.intersection(['grilla', 'grill', 'grillcon', 'bbq']):
+    if any(r in row for r in ["grilla", "grill", "grillcon", "bbq"]):
         url = getString("barbecue", "url")
         nextDate = nextBBQ()
         today = datetime.date.today()
@@ -468,12 +467,12 @@ def thirdFridayIn(y, m):
     return cal.monthdatescalendar(y, m)[THIRD][FRIDAY]
 
 
-def marvinBirthday(row, asList=None, asStr=None):
+def marvinBirthday(row):
     """
     Check birthday info
     """
     msg = None
-    if row.intersection(['birthday', 'födelsedag']):
+    if any(r in row for r in ["birthday", "födelsedag"]):
         try:
             url = getString("birthday", "url")
             soup = BeautifulSoup(urlopen(url), "html.parser")
@@ -495,12 +494,12 @@ def marvinBirthday(row, asList=None, asStr=None):
 
         return msg
 
-def marvinNameday(row, asList=None, asStr=None):
+def marvinNameday(row):
     """
     Check current nameday
     """
     msg = getString("nameday", "nobody")
-    if row.intersection(['nameday', 'namnsdag']):
+    if any(r in row for r in ["nameday", "namnsdag"]):
         try:
             now = datetime.datetime.now()
             raw_url = "http://api.dryg.net/dagar/v2.1/{year}/{month}/{day}"
@@ -516,34 +515,35 @@ def marvinNameday(row, asList=None, asStr=None):
             msg = getString("nameday", "error")
         return msg
 
-def marvinUptime(row, asList=None, asStr=None):
+def marvinUptime(row):
     """
     Display info about uptime tournament
     """
     msg = None
-    if row.intersection(['uptime']):
+    if "uptime" in row:
         msg = getString("uptime", "info")
         return msg
 
-def marvinStream(row, asList=None, asStr=None):
+def marvinStream(row):
     """
     Display info about stream
     """
     msg = None
-    if row.intersection(['stream', 'streama', 'ström', 'strömma']):
+    if any(r in row for r in ["stream", "streama", "ström", "strömma"]):
         msg = getString("stream", "info")
         return msg
 
-def marvinPrinciple(row, asList=None, asStr=None):
+def marvinPrinciple(row):
     """
     Display one selected software principle, or provide one as random
     """
-    if row.intersection(['principle', 'princip', 'principer']):
+    if any(r in row for r in ["principle", "princip", "principer"]):
         principles = getString("principle")
-        key = row.intersection(list(principles.keys()))
-        if key:
-            return principles[key.pop()]
-        return principles[random.choice(list(principles.keys()))]
+        principleKeys = list(principles.keys())
+        matchedKeys = [k for k in row if k in principleKeys]
+        if matchedKeys:
+            return principles[matchedKeys.pop()]
+        return principles[random.choice(principleKeys)]
 
 def getJoke():
     """
@@ -559,12 +559,12 @@ def getJoke():
     except Exception:
         return getString("joke", "error")
 
-def marvinJoke(row, asList=None, asStr=None):
+def marvinJoke(row):
     """
     Display a random Chuck Norris joke
     """
     msg = None
-    if row.intersection(["joke", "skämt", "chuck norris", "chuck", "norris"]):
+    if any(r in row for r in ["joke", "skämt", "chuck norris", "chuck", "norris"]):
         msg = getJoke()
         return msg
 
@@ -580,12 +580,12 @@ def getCommit():
     except Exception:
         return getString("commit", "error")
 
-def marvinCommit(row, asList=None, asStr=None):
+def marvinCommit(row):
     """
     Display a random commit message
     """
     commitMsg = "Använd detta meddelandet: '{}'"
     msg = None
-    if row.intersection(["commit", "-m"]):
+    if any(r in row for r in ["commit", "-m"]):
         msg = getCommit()
         return commitMsg.format(msg)

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -507,8 +507,11 @@ def marvinNameday(row, asList=None, asStr=None):
             url = raw_url.format(year=now.year, month=now.month, day=now.day)
             r = requests.get(url)
             nameday_data = r.json()
-            name = ",".join(nameday_data["dagar"][0]["namnsdag"])
-            msg = getString("nameday", "somebody").format(name)
+            names = nameday_data["dagar"][0]["namnsdag"]
+            if names:
+                msg = getString("nameday", "somebody").format(",".join(names))
+            else:
+                msg = getString("nameday", "nobody")
         except Exception:
             msg = getString("nameday", "error")
         return msg

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -584,7 +584,7 @@ def marvinCommit(row, asList=None, asStr=None):
     """
     Display a random commit message
     """
-    commitMsg = "Use this message: '{}'"
+    commitMsg = "Använd detta meddelandet: '{}'"
     msg = None
     if row.intersection(["commit", "-m"]):
         msg = getCommit()

--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -121,7 +121,7 @@ def marvinGoogle(row, asList=None, asStr=None):
 
 def marvinExplainShell(row, asList=None, asStr=None):
     """
-    Let Marvin present an url to the service explin shell to
+    Let Marvin present an url to the service explain shell to
     explain a shell command.
     """
     msg = None

--- a/marvin_general_actions.py
+++ b/marvin_general_actions.py
@@ -55,7 +55,7 @@ def getAllGeneralActions():
     ]
 
 
-def marvinMorning(row, asList=None, asStr=None):
+def marvinMorning(row):
     """
     Marvin says Good morning after someone else says it
     """

--- a/marvin_strings.json
+++ b/marvin_strings.json
@@ -239,7 +239,7 @@
     },
     "nameday": {
         "somebody": "Idag har {} namnsdag",
-        "nobody": "Ingen namnsdag hittades.",
+        "nobody": "Ingen har namnsdag idag",
         "error": "Något gick snett, jag har inte en susning om någon har namnsdag idag eller inte."
     },
     "uptime": {

--- a/namedayFiles/double.json
+++ b/namedayFiles/double.json
@@ -1,0 +1,22 @@
+{
+  "cachetid": "2024-08-29 18:30:37",
+  "version": "2.1",
+  "uri": "/dagar/v2.1/2024/01/03",
+  "startdatum": "2024-01-03",
+  "slutdatum": "2024-01-03",
+  "dagar": [
+    {
+      "datum": "2024-01-03",
+      "veckodag": "Onsdag",
+      "arbetsfri dag": "Nej",
+      "röd dag": "Nej",
+      "vecka": "01",
+      "dag i vecka": "3",
+      "namnsdag": [
+        "Alfred",
+        "Alfrida"
+      ],
+      "flaggdag": ""
+    }
+  ]
+}

--- a/namedayFiles/nobody.json
+++ b/namedayFiles/nobody.json
@@ -1,0 +1,20 @@
+{
+  "cachetid": "2024-08-29 18:29:55",
+  "version": "2.1",
+  "uri": "/dagar/v2.1/2024/01/01",
+  "startdatum": "2024-01-01",
+  "slutdatum": "2024-01-01",
+  "dagar": [
+    {
+      "datum": "2024-01-01",
+      "veckodag": "Måndag",
+      "arbetsfri dag": "Ja",
+      "röd dag": "Ja",
+      "vecka": "01",
+      "dag i vecka": "1",
+      "helgdag": "Nyårsdagen",
+      "namnsdag": [],
+      "flaggdag": "Nyårsdagen"
+    }
+  ]
+}

--- a/namedayFiles/single.json
+++ b/namedayFiles/single.json
@@ -1,0 +1,21 @@
+{
+  "cachetid": "2024-08-29 18:30:25",
+  "version": "2.1",
+  "uri": "/dagar/v2.1/2024/01/02",
+  "startdatum": "2024-01-02",
+  "slutdatum": "2024-01-02",
+  "dagar": [
+    {
+      "datum": "2024-01-02",
+      "veckodag": "Tisdag",
+      "arbetsfri dag": "Nej",
+      "röd dag": "Nej",
+      "vecka": "01",
+      "dag i vecka": "2",
+      "namnsdag": [
+        "Svea"
+      ],
+      "flaggdag": ""
+    }
+  ]
+}

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -219,3 +219,8 @@ class ActionTest(unittest.TestCase):
         self.assertNameDayOutput("double", "Idag har Alfred,Alfrida namnsdag")
         # FIXME
         self.assertNameDayOutput("nobody", "Idag har  namnsdag")
+
+    def testUptime(self):
+        """Test that marvin can provide the link to the uptime tournament"""
+        self.assertStringsOutput(marvin_actions.marvinUptime, "visa lite uptime", "uptime", "info")
+        self.assertActionSilent(marvin_actions.marvinUptime, "uptimetävling")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -83,6 +83,13 @@ class ActionTest(unittest.TestCase):
                 self.assertActionOutput(marvin_actions.marvinNameday, "nameday", expectedOutput)
 
 
+    def testSmile(self):
+        """Test that marvin can smile"""
+        with mock.patch("marvin_actions.random") as r:
+            r.randint.return_value = 1
+            self.assertStringsOutput(marvin_actions.marvinSmile, "le lite?", "smile", 1)
+        self.assertActionSilent(marvin_actions.marvinSmile, "sur idag?")
+
     def testWhois(self):
         """Test that marvin responds to whois"""
         self.assertStringsOutput(marvin_actions.marvinWhoIs, "vem är marvin?", "whois")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -29,9 +29,7 @@ class ActionTest(unittest.TestCase):
 
     def executeAction(self, action, message):
         """Execute an action for a message and return the response"""
-        row = re.sub('[,.?:]', ' ', message).strip().lower().split()
-
-        return action(set(row), row, message)
+        return action(re.sub('[,.?:]', ' ', message).strip().lower().split())
 
 
     def assertActionOutput(self, action, message, expectedOutput):
@@ -104,12 +102,12 @@ class ActionTest(unittest.TestCase):
                 marvin_actions.marvinGoogle,
                 "kan du googla mos",
                 "LMGTFY https://www.google.se/search?q=mos")
-            # FIXME
             self.assertActionOutput(
                 marvin_actions.marvinGoogle,
-                "du kan googla",
-                "LMGTFY https://www.google.se/search?q=")
-        self.assertActionSilent(marvin_actions.marvinGoogle, "googol")
+                "kan du googla google mos",
+                "LMGTFY https://www.google.se/search?q=google+mos")
+        self.assertActionSilent(marvin_actions.marvinGoogle, "du kan googla")
+        self.assertActionSilent(marvin_actions.marvinGoogle, "gogool")
 
     def testExplainShell(self):
         """Test that marvin can explain shell commands"""

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -9,6 +9,7 @@ import json
 import re
 import unittest
 
+from datetime import date
 from unittest import mock
 
 import marvin_actions
@@ -46,6 +47,23 @@ class ActionTest(unittest.TestCase):
             else:
                 expectedOutput = expectedOutput.get(subkey)
         self.assertActionOutput(action, message, expectedOutput)
+
+
+    def assertBBQResponse(self, todaysDate, bbqDate, expectedMessageKey):
+        """Assert that the proper bbq message is returned, given a date"""
+        url = self.strings.get("barbecue").get("url")
+        message = self.strings.get("barbecue").get(expectedMessageKey)
+        if isinstance(message, list):
+            message = message[1]
+        if expectedMessageKey in ["base", "week", "eternity"]:
+            message = message % bbqDate
+
+        with mock.patch("marvin_actions.datetime") as d:
+            d.date.today.return_value = todaysDate
+            with mock.patch("marvin_actions.random") as r:
+                r.randint.return_value = 1
+                expected = f"{url}. {message}"
+                self.assertActionOutput(marvin_actions.marvinTimeToBBQ, "dags att grilla", expected)
 
 
     def testWhois(self):
@@ -156,3 +174,16 @@ class ActionTest(unittest.TestCase):
         with mock.patch("marvin_actions.random") as r:
             r.randint.return_value = 123
             self.assertActionOutput(marvin_actions.marvinStrip, "random strip kanske?", expected)
+
+    def testTimeToBBQ(self):
+        """Test that marvin knows when the next BBQ is"""
+        self.assertBBQResponse(date(2024, 5, 17), date(2024, 5, 17), "today")
+        self.assertBBQResponse(date(2024, 5, 16), date(2024, 5, 17), "tomorrow")
+        self.assertBBQResponse(date(2024, 5, 10), date(2024, 5, 17), "week")
+        self.assertBBQResponse(date(2024, 5, 1), date(2024, 5, 17), "base")
+        self.assertBBQResponse(date(2023, 10, 17), date(2024, 5, 17), "eternity")
+
+        self.assertBBQResponse(date(2024, 9, 20), date(2024, 9, 20), "today")
+        self.assertBBQResponse(date(2024, 9, 19), date(2024, 9, 20), "tomorrow")
+        self.assertBBQResponse(date(2024, 9, 13), date(2024, 9, 20), "week")
+        self.assertBBQResponse(date(2024, 9, 4), date(2024, 9, 20), "base")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -141,3 +141,18 @@ class ActionTest(unittest.TestCase):
             self.assertActionOutput(
                 marvin_actions.marvinLunch, "dags att luncha", "Jag är lite sugen på Indiska?")
         self.assertActionSilent(marvin_actions.marvinLunch, "matdags")
+
+    def testStrip(self):
+        """Test that marvin can recommend comics"""
+        messageFormat = self.strings.get("commitstrip").get("message")
+        expected = messageFormat.format(url=self.strings.get("commitstrip").get("url"))
+        self.assertActionOutput(marvin_actions.marvinStrip, "lite strip kanske?", expected)
+        self.assertActionSilent(marvin_actions.marvinStrip, "nostrip")
+
+    def testRandomStrip(self):
+        """Test that marvin can recommend random comics"""
+        messageFormat = self.strings.get("commitstrip").get("message")
+        expected = messageFormat.format(url=self.strings.get("commitstrip").get("urlPage") + "123")
+        with mock.patch("marvin_actions.random") as r:
+            r.randint.return_value = 123
+            self.assertActionOutput(marvin_actions.marvinStrip, "random strip kanske?", expected)

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -50,3 +50,15 @@ class ActionTest(unittest.TestCase):
         self.assertStringsOutput(marvin_actions.marvinWhoIs, "vem är marvin?", "whois")
         self.assertActionSilent(marvin_actions.marvinWhoIs, "vemär")
 
+    def testExplainShell(self):
+        """Test that marvin can explain shell commands"""
+        url = "http://explainshell.com/explain?cmd=pwd"
+        self.assertActionOutput(marvin_actions.marvinExplainShell, "explain pwd", url)
+        self.assertActionOutput(marvin_actions.marvinExplainShell, "can you explain pwd", url)
+        self.assertActionOutput(
+            marvin_actions.marvinExplainShell,
+            "förklara pwd|grep -o $user",
+            f"{url}%7Cgrep+-o+%24user")
+
+        self.assertActionSilent(marvin_actions.marvinExplainShell, "explains")
+

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -91,3 +91,15 @@ class ActionTest(unittest.TestCase):
             for i,_ in enumerate(self.strings.get("hitchhiker")):
                 r.randint.return_value = i
                 self.assertStringsOutput(marvin_actions.marvinQuote, "quote", "hitchhiker", i)
+
+    def testVideoOfToday(self):
+        """Test that marvin can link to a different video each day of the week"""
+        with mock.patch("marvin_actions.datetime") as dt:
+            for d in range(1, 8):
+                dt.date.weekday.return_value = d - 1
+                day =  self.strings.get("weekdays").get(str(d))
+                video = self.strings.get("video-of-today").get(str(d))
+                response = f"{day} En passande video är {video}"
+                self.assertActionOutput(marvin_actions.marvinVideoOfToday, "dagens video", response)
+        self.assertActionSilent(marvin_actions.marvinVideoOfToday, "videoidag")
+

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -68,3 +68,10 @@ class ActionTest(unittest.TestCase):
         self.assertStringsOutput(marvin_actions.marvinSource, "källkod", "source")
         self.assertActionSilent(marvin_actions.marvinSource, "opensource")
 
+    def testBudord(self):
+        """Test that marvin knows all the commandments"""
+        for n in range(1, 5):
+            self.assertStringsOutput(marvin_actions.marvinBudord, f"budord #{n}", "budord", f"#{n}")
+
+        self.assertStringsOutput(marvin_actions.marvinBudord,"visa stentavla 1", "budord", "#1")
+        self.assertActionSilent(marvin_actions.marvinBudord, "var är stentavlan?")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -239,3 +239,19 @@ class ActionTest(unittest.TestCase):
             r.choice.return_value = "dry"
             self.assertStringsOutput(marvin_actions.marvinPrinciple, "princip", "principle", "dry")
         self.assertActionSilent(marvin_actions.marvinPrinciple, "principlös")
+
+    def testCommitRequest(self):
+        """Test that marvin sends proper requests when generating commit messages"""
+        with mock.patch("marvin_actions.requests") as r:
+            self.executeAction(marvin_actions.marvinCommit, "vad skriver man efter commit -m?")
+            self.assertEqual(r.get.call_args.args[0], "http://whatthecommit.com/index.txt")
+
+    def testCommitResponse(self):
+        """Test that marvin properly handles responses when generating commit messages"""
+        message = "Secret sauce #9"
+        response = requests.models.Response()
+        response._content = str.encode(message)
+        with mock.patch("marvin_actions.requests") as r:
+            r.get.return_value = response
+            expected = f"Use this message: '{message}'"
+            self.assertActionOutput(marvin_actions.marvinCommit, "commit", expected)

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -62,3 +62,9 @@ class ActionTest(unittest.TestCase):
 
         self.assertActionSilent(marvin_actions.marvinExplainShell, "explains")
 
+    def testSource(self):
+        """Test that marvin responds to questions about source code"""
+        self.assertStringsOutput(marvin_actions.marvinSource, "source", "source")
+        self.assertStringsOutput(marvin_actions.marvinSource, "källkod", "source")
+        self.assertActionSilent(marvin_actions.marvinSource, "opensource")
+

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -224,3 +224,8 @@ class ActionTest(unittest.TestCase):
         """Test that marvin can provide the link to the uptime tournament"""
         self.assertStringsOutput(marvin_actions.marvinUptime, "visa lite uptime", "uptime", "info")
         self.assertActionSilent(marvin_actions.marvinUptime, "uptimetävling")
+
+    def testStream(self):
+        """Test that marvin can provide the link to the stream"""
+        self.assertStringsOutput(marvin_actions.marvinStream, "ska mos streama?", "stream", "info")
+        self.assertActionSilent(marvin_actions.marvinStream, "är mos en streamer?")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -95,6 +95,21 @@ class ActionTest(unittest.TestCase):
         self.assertStringsOutput(marvin_actions.marvinWhoIs, "vem är marvin?", "whois")
         self.assertActionSilent(marvin_actions.marvinWhoIs, "vemär")
 
+    def testGoogle(self):
+        """Test that marvin can help google stuff"""
+        with mock.patch("marvin_actions.random") as r:
+            r.randint.return_value = 1
+            self.assertActionOutput(
+                marvin_actions.marvinGoogle,
+                "kan du googla mos",
+                "LMGTFY https://www.google.se/search?q=mos")
+            # FIXME
+            self.assertActionOutput(
+                marvin_actions.marvinGoogle,
+                "du kan googla",
+                "LMGTFY https://www.google.se/search?q=")
+        self.assertActionSilent(marvin_actions.marvinGoogle, "googol")
+
     def testExplainShell(self):
         """Test that marvin can explain shell commands"""
         url = "http://explainshell.com/explain?cmd=pwd"

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -15,6 +15,7 @@ from unittest import mock
 import requests
 
 import marvin_actions
+import marvin_general_actions
 
 class ActionTest(unittest.TestCase):
     """Test Marvin actions"""
@@ -276,3 +277,17 @@ class ActionTest(unittest.TestCase):
             r.get.return_value = response
             expected = f"Använd detta meddelandet: '{message}'"
             self.assertActionOutput(marvin_actions.marvinCommit, "commit", expected)
+
+    def testMorning(self):
+        """Test that marvin wishes good morning, at most once per day"""
+        marvin_general_actions.lastDateGreeted = None
+        with mock.patch("marvin_general_actions.datetime") as d:
+            d.date.today.return_value = date(2024, 5, 17)
+            with mock.patch("marvin_general_actions.random") as r:
+                r.choice.return_value = "Morgon"
+                self.assertActionOutput(marvin_general_actions.marvinMorning, "morrn", "Morgon")
+                # Should only greet once per day
+                self.assertActionSilent(marvin_general_actions.marvinMorning, "morgon")
+                # Should greet again tomorrow
+                d.date.today.return_value = date(2024, 5, 18)
+                self.assertActionOutput(marvin_general_actions.marvinMorning, "godmorgon", "Morgon")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -252,5 +252,5 @@ class ActionTest(unittest.TestCase):
         response._content = str.encode(message)
         with mock.patch("marvin_actions.requests") as r:
             r.get.return_value = response
-            expected = f"Use this message: '{message}'"
+            expected = f"Använd detta meddelandet: '{message}'"
             self.assertActionOutput(marvin_actions.marvinCommit, "commit", expected)

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -127,3 +127,17 @@ class ActionTest(unittest.TestCase):
                         r.randint.side_effect = [skey, hkey, fkey]
                         self.assertActionOutput(marvin_actions.marvinSayHi, "hej", f"{s} {h} {f}")
         self.assertActionSilent(marvin_actions.marvinSayHi, "korsning")
+
+    def testLunchLocations(self):
+        """Test that marvin can provide lunch suggestions for certain places"""
+        locations = ["karlskrona", "goteborg", "angelholm", "hassleholm", "malmo"]
+        with mock.patch("marvin_actions.random") as r:
+            for location in locations:
+                for index, place in enumerate(self.strings.get(f"lunch-{location}")):
+                    r.randint.side_effect = [0, index]
+                    self.assertActionOutput(
+                        marvin_actions.marvinLunch, f"mat {location}", f"Ska vi ta {place}?")
+            r.randint.side_effect = [1, 2]
+            self.assertActionOutput(
+                marvin_actions.marvinLunch, "dags att luncha", "Jag är lite sugen på Indiska?")
+        self.assertActionSilent(marvin_actions.marvinLunch, "matdags")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -229,3 +229,13 @@ class ActionTest(unittest.TestCase):
         """Test that marvin can provide the link to the stream"""
         self.assertStringsOutput(marvin_actions.marvinStream, "ska mos streama?", "stream", "info")
         self.assertActionSilent(marvin_actions.marvinStream, "är mos en streamer?")
+
+    def testPrinciple(self):
+        """Test that marvin can recite some software principles"""
+        principles = self.strings.get("principle")
+        for key, value in principles.items():
+            self.assertActionOutput(marvin_actions.marvinPrinciple, f"princip {key}", value)
+        with mock.patch("marvin_actions.random") as r:
+            r.choice.return_value = "dry"
+            self.assertStringsOutput(marvin_actions.marvinPrinciple, "princip", "principle", "dry")
+        self.assertActionSilent(marvin_actions.marvinPrinciple, "principlös")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -112,3 +112,8 @@ class ActionTest(unittest.TestCase):
         """Test that marvin can provide a link to the IRC stats page"""
         self.assertStringsOutput(marvin_actions.marvinStats, "stats", "ircstats")
         self.assertActionSilent(marvin_actions.marvinStats, "statistics")
+
+    def testIRCLog(self):
+        """Test that marvin can provide a link to the IRC log"""
+        self.assertStringsOutput(marvin_actions.marvinIrcLog, "irc", "irclog")
+        self.assertActionSilent(marvin_actions.marvinIrcLog, "ircstats")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -217,8 +217,7 @@ class ActionTest(unittest.TestCase):
         """Test that marvin properly parses nameday responses"""
         self.assertNameDayOutput("single", "Idag har Svea namnsdag")
         self.assertNameDayOutput("double", "Idag har Alfred,Alfrida namnsdag")
-        # FIXME
-        self.assertNameDayOutput("nobody", "Idag har  namnsdag")
+        self.assertNameDayOutput("nobody", "Ingen har namnsdag idag")
 
     def testUptime(self):
         """Test that marvin can provide the link to the uptime tournament"""

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Tests for all Marvin actions
+"""
+
+import json
+import re
+import unittest
+
+import marvin_actions
+
+class ActionTest(unittest.TestCase):
+    """Test Marvin actions"""
+    strings = {}
+
+    @classmethod
+    def setUpClass(cls):
+        with open("marvin_strings.json", encoding="utf-8") as f:
+            cls.strings = json.load(f)
+
+
+    def assertActionOutput(self, action, message, expectedOutput):
+        """Call an action on message and assert expected output"""
+        row = re.sub('[,.?:]', ' ', message).strip().lower().split()
+
+        actualOutput = action(set(row), row, message)
+
+        self.assertEqual(actualOutput, expectedOutput)
+
+
+    def assertActionSilent(self, action, message):
+        """Call an action with provided message and assert no output"""
+        self.assertActionOutput(action, message, None)
+
+
+    def assertStringsOutput(self, action, message, expectedoutputKey, subkey=None):
+        """Call an action with provided message and assert the output is equal to DB"""
+        if subkey:
+            expectedOutput = self.strings.get(expectedoutputKey).get(subkey)
+        else:
+            expectedOutput = self.strings.get(expectedoutputKey)
+
+        self.assertActionOutput(action, message, expectedOutput)
+
+
+    def testWhois(self):
+        """Test that marvin responds to whois"""
+        self.assertStringsOutput(marvin_actions.marvinWhoIs, "vem är marvin?", "whois")
+        self.assertActionSilent(marvin_actions.marvinWhoIs, "vemär")
+

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -103,3 +103,7 @@ class ActionTest(unittest.TestCase):
                 self.assertActionOutput(marvin_actions.marvinVideoOfToday, "dagens video", response)
         self.assertActionSilent(marvin_actions.marvinVideoOfToday, "videoidag")
 
+    def testHelp(self):
+        """Test that marvin can provide a help menu"""
+        self.assertStringsOutput(marvin_actions.marvinHelp, "help", "menu")
+        self.assertActionSilent(marvin_actions.marvinHelp, "halp")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -117,3 +117,13 @@ class ActionTest(unittest.TestCase):
         """Test that marvin can provide a link to the IRC log"""
         self.assertStringsOutput(marvin_actions.marvinIrcLog, "irc", "irclog")
         self.assertActionSilent(marvin_actions.marvinIrcLog, "ircstats")
+
+    def testSayHi(self):
+        """Test that marvin responds to greetings"""
+        with mock.patch("marvin_actions.random") as r:
+            for skey, s in enumerate(self.strings.get("smile")):
+                for hkey, h in enumerate(self.strings.get("hello")):
+                    for fkey, f in enumerate(self.strings.get("friendly")):
+                        r.randint.side_effect = [skey, hkey, fkey]
+                        self.assertActionOutput(marvin_actions.marvinSayHi, "hej", f"{s} {h} {f}")
+        self.assertActionSilent(marvin_actions.marvinSayHi, "korsning")

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -107,3 +107,8 @@ class ActionTest(unittest.TestCase):
         """Test that marvin can provide a help menu"""
         self.assertStringsOutput(marvin_actions.marvinHelp, "help", "menu")
         self.assertActionSilent(marvin_actions.marvinHelp, "halp")
+
+    def testStats(self):
+        """Test that marvin can provide a link to the IRC stats page"""
+        self.assertStringsOutput(marvin_actions.marvinStats, "stats", "ircstats")
+        self.assertActionSilent(marvin_actions.marvinStats, "statistics")


### PR DESCRIPTION
Now all actions only take a list of normalized words, instead of both a list, a set and a string containing the same words.

Added unittests for all working actions to enable the refactoring (Birthday, Joke, Listen, Sun and Weather depend on sites that have changed, and are thus broken right now and not covered by tests).

Also corrected some bugs found while writing the tests.