### PR TITLE
Fixes nameday formatting

### DIFF
--- a/marvin_actions.py
+++ b/marvin_actions.py
@@ -453,14 +453,23 @@ def marvinNameday(row):
             r = requests.get(url, timeout=5)
             nameday_data = r.json()
             names = nameday_data["dagar"][0]["namnsdag"]
+            parsed_names = formatNames(names)
             if names:
-                msg = getString("nameday", "somebody").format(",".join(names))
+                msg = getString("nameday", "somebody").format(parsed_names)
             else:
                 msg = getString("nameday", "nobody")
         except Exception as e:
             LOG.error("Failed to get nameday: %s", e)
             msg = getString("nameday", "error")
     return msg
+
+def formatNames(names):
+    """
+    Parses namedata from nameday API
+    """
+    if len(names) > 1:
+        return " och ".join([", ".join(names[:-1])] + names[-1:])
+    return "".join(names)
 
 def marvinUptime(row):
     """

--- a/namedayFiles/triple.json
+++ b/namedayFiles/triple.json
@@ -1,0 +1,24 @@
+{
+    "cachetid": "2025-01-23 10:31:50",
+    "version": "2.1",
+    "uri": "/dagar/v2.1/2025/01/06",
+    "startdatum": "2025-01-06",
+    "slutdatum": "2025-01-06",
+    "dagar": [
+      {
+        "datum": "2025-01-06",
+        "veckodag": "Måndag",
+        "arbetsfri dag": "Ja",
+        "röd dag": "Ja",
+        "vecka": "02",
+        "dag i vecka": "1",
+        "helgdag": "Trettondedag jul",
+        "namnsdag": [
+          "Kasper",
+          "Melker",
+          "Baltsar"
+        ],
+        "flaggdag": ""
+      }
+    ]
+}

--- a/test_marvin_actions.py
+++ b/test_marvin_actions.py
@@ -248,7 +248,8 @@ class ActionTest(TestCase):
     def testNameDayResponse(self):
         """Test that marvin properly parses nameday responses"""
         self.assertNameDayOutput("single", "Idag har Svea namnsdag")
-        self.assertNameDayOutput("double", "Idag har Alfred,Alfrida namnsdag")
+        self.assertNameDayOutput("double", "Idag har Alfred och Alfrida namnsdag")
+        self.assertNameDayOutput("triple", "Idag har Kasper, Melker och Baltsar namnsdag")
         self.assertNameDayOutput("nobody", "Ingen har namnsdag idag")
 
     def testNameDayError(self):


### PR DESCRIPTION
Former nameday formatting was: 
```"Idag har Alfrida,Alfred namnsdag"```
This PR changes it to the much prettier:
```"Idag har Alfrida och Alfred namnsdag"```
or, if it's a three name nameday:
```"Idag har Kasper, Melker och Baltsar namnsdag"```
Includes tests for formatting change.