### PR TITLE
Only deploy docs to GitHub Pages on push to master

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}/pdoc


### PR DESCRIPTION
Every PR shows a permanent red X on the "Deploy API documentation to github
pages" job. Root cause: the `github-pages` environment has a custom branch
deployment policy that only allows deployments from `master`
(confirmed via `gh api repos/mosbth/irc2phpbb/environments/github-pages`),
so the `deploy` job is rejected outright — no steps even run — whenever the
workflow triggers on a PR branch.

This gates the `deploy` job to `github.event_name == 'push' &&
github.ref == 'refs/heads/master'`. The `build` job (which actually runs
`pdoc`) still runs on every push and PR, so a broken docs build is still
caught before merge — only the deploy step, which could never succeed off
`master` anyway, is skipped.